### PR TITLE
Make U8g2TextStyle::new const and fix typos

### DIFF
--- a/regenerate_fonts_file.sh
+++ b/regenerate_fonts_file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/src/font_reader/mod.rs
+++ b/src/font_reader/mod.rs
@@ -25,8 +25,8 @@ pub struct FontReader {
     pub font_bounding_box_y_offset: i8,
     pub ascent: i8,
     pub descent: i8,
-    pub ascent_of_parantheses: i8,
-    pub descent_of_parantheses: i8,
+    pub ascent_of_parentheses: i8,
+    pub descent_of_parentheses: i8,
     pub array_offset_upper_a: u16,
     pub array_offset_lower_a: u16,
     pub array_offset_0x0100: u16,
@@ -55,8 +55,8 @@ impl FontReader {
             font_bounding_box_y_offset: data[12] as i8,
             ascent: data[13] as i8,
             descent: data[14] as i8,
-            ascent_of_parantheses: data[15] as i8,
-            descent_of_parantheses: data[16] as i8,
+            ascent_of_parentheses: data[15] as i8,
+            descent_of_parentheses: data[16] as i8,
             array_offset_upper_a: u16::from_be_bytes([data[17], data[18]]),
             array_offset_lower_a: u16::from_be_bytes([data[19], data[20]]),
             array_offset_0x0100: u16::from_be_bytes([data[21], data[22]]),
@@ -176,8 +176,8 @@ mod tests {
             font_bounding_box_y_offset: 4,
             ascent: 5,
             descent: 6,
-            ascent_of_parantheses: 7,
-            descent_of_parantheses: 8,
+            ascent_of_parentheses: 7,
+            descent_of_parentheses: 8,
             array_offset_upper_a: 0,
             array_offset_lower_a: 0,
             array_offset_0x0100: 2,
@@ -192,7 +192,7 @@ mod tests {
     fn can_handle_unicode_next_is_zero() {
         // This test is specifically engineered to test an error path that doesn't happen
         // in normal, correct fonts.
-        // This means that this should be an assert intead, but it just doesn't feel right.
+        // This means that this should be an assert instead, but it just doesn't feel right.
         // There is no formal specification that this error path is impossible, and resilient
         // programming tells me it should be a normal error path.
         // Sadly, that reduces our test coverage :D so let's trigger that error manually.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! The [`FontRenderer::render()`](FontRenderer::render) allows for basic vertical positioning. Horizontally, it renders exactly like specified in the font.
 //!
 //! For more advanced usecases, use the [`FontRenderer::render_aligned()`](FontRenderer::render_aligned) method.
-//! It further allows for horizontal alignment through an aditional parameter.
+//! It further allows for horizontal alignment through an additional parameter.
 //!
 //! ## Bounding Box Calculation
 //!

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -39,7 +39,7 @@ impl FontRenderer {
     /// Switches the font rendering mode to ignore all unrenderable characters
     /// instead of raising an error.
     ///
-    /// By default, unkown chars will return an error.
+    /// By default, unknown chars will return an error.
     ///
     /// # Arguments
     ///

--- a/src/u8g2_text_style.rs
+++ b/src/u8g2_text_style.rs
@@ -40,8 +40,9 @@ pub struct U8g2TextStyle<C> {
 
 impl<C> U8g2TextStyle<C> {
     /// Creates a text style with transparent background.
-    pub fn new<F: Font>(font: F, text_color: C) -> Self {
-        drop(font);
+    pub const fn new<F: Font>(font: F, text_color: C) -> Self {
+        // font is a ZST, so it's safe to forget it
+        core::mem::forget(font);
         Self {
             text_color: Some(text_color),
             background_color: None,


### PR DESCRIPTION
Having a `const` variant of `U8g2TextStyle::new` allows defining font styles once and then reusing them across multiple functions without the need to pass references around, which makes decomposition of big `draw()` functions easier.

The new function is slightly less ergonomic than `new`, but it avoids unnecessary `drop` (which is not `const`):
```rust
const BIG_CHAR_STYLE: U8g2TextStyle<Color> =
    U8g2TextStyle::new_const::<fonts::u8g2_font_spleen16x32_mn>(Color::Black);
```