### PR TITLE
Add background rendering support for non-monospaced fonts (prototype)

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -95,9 +95,9 @@ impl FontRenderer {
         Display: DrawTarget,
     {
         let font = &self.font;
-        if color.has_background() && !font.supports_background_color {
-            return Err(Error::BackgroundColorNotSupported);
-        }
+        // if color.has_background() && !font.supports_background_color {
+        //     return Err(Error::BackgroundColorNotSupported);
+        // }
 
         let mut advance = Point::new(0, 0);
 
@@ -177,9 +177,9 @@ impl FontRenderer {
         // glyphs/lines, but makes it possible to implement the format_args case.
 
         let font = &self.font;
-        if color.has_background() && !font.supports_background_color {
-            return Err(Error::BackgroundColorNotSupported);
-        }
+        // if color.has_background() && !font.supports_background_color {
+        //     return Err(Error::BackgroundColorNotSupported);
+        // }
 
         position.y += content.compute_vertical_offset(font, vertical_pos);
 

--- a/src/renderer/render_actions.rs
+++ b/src/renderer/render_actions.rs
@@ -132,7 +132,10 @@ where
                 renderer.render_transparent(position, display, color)?
             }
             FontColor::WithBackground { fg, bg } => {
-                renderer.render_as_box_fill(position, display, fg, bg)?
+                match font.supports_background_color {
+                    true => renderer.render_as_box_fill(position, display, fg, bg)?,
+                    false => renderer.render_with_advance_fill(position, display, fg, bg)?,
+                }
             }
         })
     } else {


### PR DESCRIPTION
# Overview

This PR adds background color fill support for non-monospaced fonts (which currently panics on `Error::BackgroundColorNotSupported`). For calculating the fill bounding box, a left and right padding is added to the bounding box of each non-monospace glyph using its advance.

## Uses

When refreshing text, a full redraw is not preferable because of flickering. Monospaced fonts are preferred due to them having a background which can be contiguously filled along with the glyph foreground on a single draw call, thereby reducing flicker.

A present solution for non-monospaced fonts is presented in the [mouse position example](https://github.com/Finomnis/u8g2-fonts/blob/main/examples/simulator/src/bin/mouse_position.rs). The previous text is re-rendered as to clear the screen. Then, new text is added. Just like drawing a rectangle to clear the screen, this involves two draw calls.

Here, common non-monospace fonts, such as Helvetica `u8g2_font_helvB`, and Courier `u8g2_font_courB` can thus be drawn more effectively.

Below is an example of `u8g2_font_logisoso32_tn` (non-monospaced) refreshing with on an ST7789 TFT display.
The text background is set as black, while the text is set as white. Every refresh draws the background and new text over the previous text.

<img src="https://github.com/user-attachments/assets/9675d53e-fe57-44ea-bb2f-e0a86d770b9c" width="512px" />

```rust
    let mut style = U8g2TextStyle::new(fonts::u8g2_font_logisoso32_tn, Rgb565::CSS_WHITE);
    style.set_background_color(Some(Rgb565::BLACK));

    let align = TextStyleBuilder::new()
        .alignment(Alignment::Right)
        .baseline(Baseline::Top)
        .build();

    Text::with_text_style(
        format_f32::<8>(readout.voltage, 3).as_str(),
        Point::new(122, 30),
        style.clone(),
        align,
    )
    .draw(target)
    .map_err(|_| ())?;
```

## Next-steps

- [x] Initial prototype & proposal
- [ ] How can this feature be packaged within `u8g2-fonts`? Maybe behind an extra cargo feature?
- [ ] Write tests to ensure coverage
- [ ] Add an example within `examples/simulator`
- [ ] Documentation
- [ ] 🚀

### Feedback welcome

Thoughts on how to integrate this into the package? I'd be happy to polish, add tests, etc., since this is currently a prototype to make my own project work!