### PR TITLE
Const glyph index, glyph iter and a bug fix

### DIFF
--- a/src/font_reader/glyph_index.rs
+++ b/src/font_reader/glyph_index.rs
@@ -26,7 +26,7 @@ pub enum IndexLookup {
 ///
 /// The offsets are relative to the start of the glyph data, identical to what
 /// [`find_glyph_offset`] computes.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct GlyphIndex {
     offsets: [u16; NUM_CHARS],
 }
@@ -94,14 +94,16 @@ mod tests {
     use crate::{font_reader::glyph_searcher, fonts};
 
     /// Runs `check` on a selection of fonts with different glyph ranges, bit widths
-    /// and encodings. `check` receives the font name, a plain and an indexed reader.
-    fn for_each_test_font(check: impl Fn(&str, &FontReader, &FontReader)) {
+    /// and encodings. `check` receives the font name, a plain and an indexed reader,
+    /// and an index that is built at runtime instead of at compile time.
+    fn for_each_test_font(check: impl Fn(&str, &FontReader, &FontReader, Option<GlyphIndex>)) {
         macro_rules! check_font {
             ($font:ty) => {
                 check(
                     stringify!($font),
                     &FontReader::new::<$font>(),
                     &FontReader::new_indexed::<$font>(),
+                    GlyphIndex::build_for::<$font>(),
                 )
             };
         }
@@ -118,8 +120,22 @@ mod tests {
     }
 
     #[test]
+    fn the_index_does_not_depend_on_when_it_is_built() {
+        for_each_test_font(|name, plain, indexed, at_runtime| {
+            assert_eq!(at_runtime.as_ref(), indexed.glyph_index, "{name}");
+
+            let from_data = GlyphIndex::build(
+                &plain.data,
+                plain.array_offset_upper_a,
+                plain.array_offset_lower_a,
+            );
+            assert_eq!(from_data.as_ref(), indexed.glyph_index, "{name}");
+        });
+    }
+
+    #[test]
     fn index_matches_linear_search() {
-        for_each_test_font(|name, plain, indexed| {
+        for_each_test_font(|name, plain, indexed, _| {
             assert!(indexed.glyph_index.is_some(), "{name} has no glyph index");
 
             for encoding in FIRST_CHAR..=LAST_CHAR {
@@ -179,6 +195,33 @@ mod tests {
                 font.find_glyph_offset(encoding)
             );
         }
+    }
+
+    #[test]
+    fn fonts_with_glyphs_beyond_the_offset_range_have_no_index() {
+        // The offset of the only glyph, which is too large for the index.
+        const FAR_OFFSET: usize = ABSENT as usize;
+
+        static DATA: [u8; glyph_searcher::U8G2_FONT_DATA_STRUCT_SIZE + FAR_OFFSET + 2] = {
+            let mut data = [0; glyph_searcher::U8G2_FONT_DATA_STRUCT_SIZE + FAR_OFFSET + 2];
+
+            // A chain of entries that are no glyphs, leading up to the glyph of a space.
+            let mut offset = 0;
+            while offset < FAR_OFFSET {
+                let remaining = FAR_OFFSET - offset;
+                let jump_distance = if remaining > 255 { 255 } else { remaining };
+                data[glyph_searcher::U8G2_FONT_DATA_STRUCT_SIZE + offset] = 0x01;
+                data[glyph_searcher::U8G2_FONT_DATA_STRUCT_SIZE + offset + 1] = jump_distance as u8;
+                offset += jump_distance;
+            }
+            data[glyph_searcher::U8G2_FONT_DATA_STRUCT_SIZE + FAR_OFFSET] = b' ';
+            data[glyph_searcher::U8G2_FONT_DATA_STRUCT_SIZE + FAR_OFFSET + 1] = 2;
+
+            data
+        };
+
+        assert_eq!(find_glyph_offset(&DATA, 0, 0, b' '), Some(FAR_OFFSET));
+        assert!(GlyphIndex::build(&DATA, 0, 0).is_none());
     }
 
     // Proves that the whole index is computed at compile time.

--- a/src/font_reader/glyph_index.rs
+++ b/src/font_reader/glyph_index.rs
@@ -1,0 +1,194 @@
+use crate::{
+    font_reader::{glyph_searcher::find_glyph_offset, FontReader},
+    Font,
+};
+
+/// The first character covered by a [`GlyphIndex`].
+pub const FIRST_CHAR: u8 = 0x20;
+
+/// The last character covered by a [`GlyphIndex`].
+pub const LAST_CHAR: u8 = 0x7e;
+
+/// The number of characters covered by a [`GlyphIndex`].
+pub const NUM_CHARS: usize = (LAST_CHAR - FIRST_CHAR) as usize + 1;
+
+/// Marks a character that the font does not contain.
+const ABSENT: u16 = u16::MAX;
+
+/// The result of a [`GlyphIndex`] lookup.
+pub enum IndexLookup {
+    Found(usize),
+    Absent,
+    NotCovered,
+}
+
+/// A table that maps the printable ASCII characters to the offsets of their glyphs.
+///
+/// The offsets are relative to the start of the glyph data, identical to what
+/// [`find_glyph_offset`] computes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GlyphIndex {
+    offsets: [u16; NUM_CHARS],
+}
+
+impl GlyphIndex {
+    /// Builds the index by walking the jump chain of the font once per character.
+    ///
+    /// Returns [`None`] if one of the offsets does not fit into a [`u16`], in which
+    /// case the caller has to fall back to searching the jump chain at runtime.
+    pub const fn build(
+        data: &[u8],
+        array_offset_upper_a: u16,
+        array_offset_lower_a: u16,
+    ) -> Option<Self> {
+        let mut offsets = [ABSENT; NUM_CHARS];
+
+        let mut i = 0;
+        while i < NUM_CHARS {
+            let encoding = FIRST_CHAR + i as u8;
+
+            if let Some(offset) =
+                find_glyph_offset(data, array_offset_upper_a, array_offset_lower_a, encoding)
+            {
+                if offset >= ABSENT as usize {
+                    return None;
+                }
+                offsets[i] = offset as u16;
+            }
+
+            i += 1;
+        }
+
+        Some(Self { offsets })
+    }
+
+    /// Builds the index of the font `F`.
+    pub const fn build_for<F: Font>() -> Option<Self> {
+        let font = FontReader::new::<F>();
+
+        Self::build(
+            F::DATA,
+            font.array_offset_upper_a,
+            font.array_offset_lower_a,
+        )
+    }
+
+    /// Looks up the offset of the glyph of `encoding`.
+    pub const fn lookup(&self, encoding: u8) -> IndexLookup {
+        if encoding < FIRST_CHAR || encoding > LAST_CHAR {
+            return IndexLookup::NotCovered;
+        }
+
+        match self.offsets[(encoding - FIRST_CHAR) as usize] {
+            ABSENT => IndexLookup::Absent,
+            offset => IndexLookup::Found(offset as usize),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use crate::{font_reader::glyph_searcher, fonts};
+
+    /// Runs `check` on a selection of fonts with different glyph ranges, bit widths
+    /// and encodings. `check` receives the font name, a plain and an indexed reader.
+    fn for_each_test_font(check: impl Fn(&str, &FontReader, &FontReader)) {
+        macro_rules! check_font {
+            ($font:ty) => {
+                check(
+                    stringify!($font),
+                    &FontReader::new::<$font>(),
+                    &FontReader::new_indexed::<$font>(),
+                )
+            };
+        }
+
+        check_font!(fonts::u8g2_font_ncenB14_tr);
+        check_font!(fonts::u8g2_font_courB10_tn);
+        check_font!(fonts::u8g2_font_lubBI08_tf);
+        check_font!(fonts::u8g2_font_u8glib_4_tf);
+        check_font!(fonts::u8g2_font_4x6_mr);
+        check_font!(fonts::u8g2_font_10x20_me);
+        check_font!(fonts::u8g2_font_osb41_tf);
+        check_font!(fonts::u8g2_font_haxrcorp4089_t_cyrillic);
+        check_font!(fonts::u8g2_font_unifont_t_symbols);
+    }
+
+    #[test]
+    fn index_matches_linear_search() {
+        for_each_test_font(|name, plain, indexed| {
+            assert!(indexed.glyph_index.is_some(), "{name} has no glyph index");
+
+            for encoding in FIRST_CHAR..=LAST_CHAR {
+                let ch = encoding as char;
+                let expected = glyph_searcher::find_glyph_offset(
+                    &plain.data,
+                    plain.array_offset_upper_a,
+                    plain.array_offset_lower_a,
+                    encoding,
+                );
+
+                assert_eq!(
+                    indexed.find_glyph_offset(encoding),
+                    expected,
+                    "{name}: index disagrees for {ch:?}"
+                );
+                assert_eq!(
+                    plain.find_glyph_offset(encoding),
+                    expected,
+                    "{name}: linear search disagrees for {ch:?}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn index_reports_absent_glyphs() {
+        // A number-only font does not contain any letters.
+        let font = FontReader::new_indexed::<fonts::u8g2_font_courB10_tn>();
+
+        for encoding in *b"aAz" {
+            assert!(matches!(
+                font.glyph_index.unwrap().lookup(encoding),
+                IndexLookup::Absent
+            ));
+            assert_eq!(font.find_glyph_offset(encoding), None);
+        }
+
+        assert!(matches!(
+            font.glyph_index.unwrap().lookup(b'0'),
+            IndexLookup::Found(_)
+        ));
+    }
+
+    #[test]
+    fn characters_outside_of_the_index_are_searched_linearly() {
+        let font = FontReader::new::<fonts::u8g2_font_lubBI08_tf>();
+        let indexed = FontReader::new_indexed::<fonts::u8g2_font_lubBI08_tf>();
+
+        for encoding in [0x00u8, 0x1f, 0x7f, 0xe4, 0xff] {
+            assert!(matches!(
+                indexed.glyph_index.unwrap().lookup(encoding),
+                IndexLookup::NotCovered
+            ));
+            assert_eq!(
+                indexed.find_glyph_offset(encoding),
+                font.find_glyph_offset(encoding)
+            );
+        }
+    }
+
+    // Proves that the whole index is computed at compile time.
+    const INDEXED_FONT: FontReader = FontReader::new_indexed::<fonts::u8g2_font_ncenB14_tr>();
+
+    const SPACE_LOOKUP: IndexLookup = match INDEXED_FONT.glyph_index {
+        Some(index) => index.lookup(b' '),
+        None => IndexLookup::NotCovered,
+    };
+
+    const _: () = assert!(INDEXED_FONT.glyph_index.is_some());
+    const _: () = assert!(matches!(SPACE_LOOKUP, IndexLookup::Found(_)));
+}

--- a/src/font_reader/glyph_searcher.rs
+++ b/src/font_reader/glyph_searcher.rs
@@ -31,7 +31,62 @@ impl<const CHAR_WIDTH: usize> GlyphSearcher<'_, CHAR_WIDTH> {
     }
 }
 
-const U8G2_FONT_DATA_STRUCT_SIZE: usize = 23;
+pub const U8G2_FONT_DATA_STRUCT_SIZE: usize = 23;
+
+/// An entry of the single byte encoding jump chain.
+pub struct SingleByteEntry {
+    pub encoding: u8,
+    /// The distance to the next entry. A distance of zero terminates the chain.
+    pub jump_distance: u8,
+}
+
+/// Reads the entry of the single byte encoding jump chain at `pos`.
+///
+/// `pos` is an index into `data`, not an offset into the glyph data.
+///
+/// Returns [`None`] if `data` is too short to contain the entry.
+pub const fn read_single_byte_entry(data: &[u8], pos: usize) -> Option<SingleByteEntry> {
+    if pos + 1 >= data.len() {
+        return None;
+    }
+
+    Some(SingleByteEntry {
+        encoding: data[pos],
+        jump_distance: data[pos + 1],
+    })
+}
+
+/// An entry of the unicode jump chain.
+pub struct UnicodeEntry {
+    /// An encoding of zero terminates the chain.
+    pub encoding: u16,
+    /// The distance to the next entry. A distance of zero terminates the chain.
+    pub jump_distance: u8,
+}
+
+/// Reads the entry of the unicode jump chain at `pos`.
+///
+/// `pos` is an index into `data`, not an offset into the glyph data.
+///
+/// Returns [`None`] if `data` is too short to contain the entry. The chain
+/// terminator consists of the encoding alone, so a missing jump distance is
+/// reported as zero.
+pub const fn read_unicode_entry(data: &[u8], pos: usize) -> Option<UnicodeEntry> {
+    if pos + 1 >= data.len() {
+        return None;
+    }
+
+    let jump_distance = if pos + 2 < data.len() {
+        data[pos + 2]
+    } else {
+        0
+    };
+
+    Some(UnicodeEntry {
+        encoding: u16::from_be_bytes([data[pos], data[pos + 1]]),
+        jump_distance,
+    })
+}
 
 /// Walks the jump chain of the single byte encoding region and returns the offset
 /// of the glyph of `encoding`, relative to the start of the glyph data.
@@ -56,22 +111,20 @@ pub const fn find_glyph_offset(
     };
 
     loop {
-        let pos = U8G2_FONT_DATA_STRUCT_SIZE + offset;
-
-        if pos + 1 >= data.len() {
-            return None;
-        }
+        let entry = match read_single_byte_entry(data, U8G2_FONT_DATA_STRUCT_SIZE + offset) {
+            Some(entry) => entry,
+            None => return None,
+        };
 
         // The terminator of the chain is not a glyph, so it is checked first.
-        let jump_distance = data[pos + 1];
-        if jump_distance == 0 {
+        if entry.jump_distance == 0 {
             return None;
         }
-        if data[pos] == encoding {
+        if entry.encoding == encoding {
             return Some(offset);
         }
 
-        offset += jump_distance as usize;
+        offset += entry.jump_distance as usize;
     }
 }
 

--- a/src/font_reader/glyph_searcher.rs
+++ b/src/font_reader/glyph_searcher.rs
@@ -16,6 +16,11 @@ impl<const CHAR_WIDTH: usize> GlyphSearcher<'_, CHAR_WIDTH> {
         self.data.get(CHAR_WIDTH).cloned().unwrap()
     }
 
+    /// Returns whether the searcher points at the terminator of the glyph list.
+    pub fn is_at_terminator(&self) -> bool {
+        self.get_offset() == 0
+    }
+
     pub fn jump_to_next(&mut self) -> bool {
         let offset = self.get_offset();
         if offset == 0 {

--- a/src/font_reader/glyph_searcher.rs
+++ b/src/font_reader/glyph_searcher.rs
@@ -16,11 +16,6 @@ impl<const CHAR_WIDTH: usize> GlyphSearcher<'_, CHAR_WIDTH> {
         self.data.get(CHAR_WIDTH).cloned().unwrap()
     }
 
-    /// Returns whether the searcher points at the terminator of the glyph list.
-    pub fn is_at_terminator(&self) -> bool {
-        self.get_offset() == 0
-    }
-
     pub fn jump_to_next(&mut self) -> bool {
         let offset = self.get_offset();
         if offset == 0 {
@@ -38,16 +33,54 @@ impl<const CHAR_WIDTH: usize> GlyphSearcher<'_, CHAR_WIDTH> {
 
 const U8G2_FONT_DATA_STRUCT_SIZE: usize = 23;
 
+/// Walks the jump chain of the single byte encoding region and returns the offset
+/// of the glyph of `encoding`, relative to the start of the glyph data.
+///
+/// The returned value is exactly the value that has to be passed to
+/// [`GlyphSearcher::jump_by`] to make a freshly created [`GlyphSearcher<1>`]
+/// point at the glyph of `encoding`.
+///
+/// Returns [`None`] if the font does not contain `encoding`.
+pub const fn find_glyph_offset(
+    data: &[u8],
+    array_offset_upper_a: u16,
+    array_offset_lower_a: u16,
+    encoding: u8,
+) -> Option<usize> {
+    let mut offset = if encoding >= b'a' {
+        array_offset_lower_a as usize
+    } else if encoding >= b'A' {
+        array_offset_upper_a as usize
+    } else {
+        0
+    };
+
+    loop {
+        let pos = U8G2_FONT_DATA_STRUCT_SIZE + offset;
+
+        if pos + 1 >= data.len() {
+            return None;
+        }
+
+        // The terminator of the chain is not a glyph, so it is checked first.
+        let jump_distance = data[pos + 1];
+        if jump_distance == 0 {
+            return None;
+        }
+        if data[pos] == encoding {
+            return Some(offset);
+        }
+
+        offset += jump_distance as usize;
+    }
+}
+
 impl<'a> GlyphSearcher<'a, 1> {
     pub fn new(font: &'a FontReader) -> Self {
         Self {
             data: &font.data[U8G2_FONT_DATA_STRUCT_SIZE..],
             font,
         }
-    }
-
-    pub fn get_ch(&self) -> u8 {
-        self.data.first().cloned().unwrap()
     }
 
     pub fn into_unicode_mode(

--- a/src/font_reader/glyph_searcher.rs
+++ b/src/font_reader/glyph_searcher.rs
@@ -160,3 +160,40 @@ impl GlyphSearcher<'_, 2> {
         ])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_byte_entries_need_an_encoding_and_a_jump_distance() {
+        assert!(read_single_byte_entry(&[0x41], 0).is_none());
+
+        let entry = read_single_byte_entry(&[0xff, 0x41, 0x07], 1).unwrap();
+        assert_eq!(entry.encoding, 0x41);
+        assert_eq!(entry.jump_distance, 0x07);
+    }
+
+    #[test]
+    fn a_jump_chain_that_leaves_the_data_does_not_find_a_glyph() {
+        let mut data = [0; U8G2_FONT_DATA_STRUCT_SIZE + 3];
+        data[U8G2_FONT_DATA_STRUCT_SIZE] = b'A';
+        // The jump distance points behind the end of the data.
+        data[U8G2_FONT_DATA_STRUCT_SIZE + 1] = 4;
+
+        assert!(find_glyph_offset(&data, 0, 0, b'B').is_none());
+    }
+
+    #[test]
+    fn unicode_entries_need_an_encoding_and_may_omit_the_jump_distance() {
+        assert!(read_unicode_entry(&[0x04], 0).is_none());
+
+        let terminator = read_unicode_entry(&[0x00, 0x00], 0).unwrap();
+        assert_eq!(terminator.encoding, 0x0000);
+        assert_eq!(terminator.jump_distance, 0);
+
+        let entry = read_unicode_entry(&[0x04, 0x10, 0x09], 0).unwrap();
+        assert_eq!(entry.encoding, 0x0410);
+        assert_eq!(entry.jump_distance, 0x09);
+    }
+}

--- a/src/font_reader/glyphs.rs
+++ b/src/font_reader/glyphs.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// The region of the font data that the iterator is currently walking.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 enum Region {
     /// Walking the single byte encoding chain, at the given index into the data.
     SingleByte(usize),
@@ -93,5 +93,50 @@ impl Iterator for Glyphs {
                 Region::Finished => return None,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use std::vec::Vec;
+
+    use super::*;
+
+    /// Builds font data out of a header whose unicode region starts right behind the
+    /// terminator of the single byte encoding chain, that terminator, and the unicode
+    /// region passed as arguments.
+    macro_rules! font_data {
+        ($($byte:expr),* $(,)?) => {
+            &[
+                0, 0, 4, 4, 8, 8, 8, 8, 8, 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 2, // Header
+                0, 0, // Terminator of the single byte encoding chain
+                $($byte,)*
+            ]
+        };
+    }
+
+    fn glyphs_of(data: &'static [u8]) -> Vec<char> {
+        FontReader::new_from_raw_data(data).glyphs().collect()
+    }
+
+    #[test]
+    fn a_font_ends_if_its_unicode_region_lies_behind_the_data() {
+        assert!(glyphs_of(font_data![]).is_empty());
+    }
+
+    #[test]
+    fn the_last_unicode_entry_may_omit_its_jump_distance() {
+        // A jump table that leads to a single entry that has no jump distance.
+        assert_eq!(
+            glyphs_of(font_data![0, 4, 0xff, 0xff, 0x04, 0x10]),
+            ['\u{410}']
+        );
+    }
+
+    #[test]
+    fn unicode_entries_that_are_no_characters_are_skipped() {
+        // 0xd800 is a surrogate, so it is not a character.
+        assert!(glyphs_of(font_data![0, 4, 0xff, 0xff, 0xd8, 0x00, 3, 0, 0]).is_empty());
     }
 }

--- a/src/font_reader/glyphs.rs
+++ b/src/font_reader/glyphs.rs
@@ -1,0 +1,97 @@
+use crate::{
+    font_reader::{
+        glyph_searcher::{read_single_byte_entry, read_unicode_entry, U8G2_FONT_DATA_STRUCT_SIZE},
+        FontReader,
+    },
+    utils::DebugIgnore,
+};
+
+/// The region of the font data that the iterator is currently walking.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Region {
+    /// Walking the single byte encoding chain, at the given index into the data.
+    SingleByte(usize),
+    /// Walking the unicode chain, at the given index into the data.
+    Unicode(usize),
+    /// Both chains have been walked to their end.
+    Finished,
+}
+
+/// An iterator over the characters that a font contains.
+///
+/// Yields the characters in the order in which they are stored in the font,
+/// which is ascending by code point.
+///
+/// Created by [`FontRenderer::glyphs()`](crate::FontRenderer::glyphs).
+#[derive(Clone, Debug)]
+pub struct Glyphs {
+    data: DebugIgnore<&'static [u8]>,
+    unicode_region: usize,
+    region: Region,
+}
+
+impl Glyphs {
+    pub(crate) fn new(font: &FontReader) -> Self {
+        Self {
+            data: DebugIgnore(font.data.0),
+            unicode_region: U8G2_FONT_DATA_STRUCT_SIZE + usize::from(font.array_offset_0x0100),
+            region: Region::SingleByte(U8G2_FONT_DATA_STRUCT_SIZE),
+        }
+    }
+
+    /// Computes the position of the first entry of the unicode chain.
+    ///
+    /// The unicode region starts with the unicode jump table, whose first entry
+    /// contains the distance from the region to the first glyph.
+    fn first_unicode_entry(&self) -> Option<usize> {
+        let data = self
+            .data
+            .get(self.unicode_region..self.unicode_region + 2)?;
+        let jump_distance = u16::from_be_bytes([data[0], data[1]]);
+
+        Some(self.unicode_region + usize::from(jump_distance))
+    }
+}
+
+impl Iterator for Glyphs {
+    type Item = char;
+
+    fn next(&mut self) -> Option<char> {
+        loop {
+            match self.region {
+                Region::SingleByte(pos) => match read_single_byte_entry(&self.data, pos) {
+                    Some(entry) if entry.jump_distance != 0 => {
+                        self.region = Region::SingleByte(pos + usize::from(entry.jump_distance));
+                        return Some(char::from(entry.encoding));
+                    }
+                    _ => {
+                        self.region = match self.first_unicode_entry() {
+                            Some(pos) => Region::Unicode(pos),
+                            None => Region::Finished,
+                        };
+                    }
+                },
+                Region::Unicode(pos) => {
+                    let entry = match read_unicode_entry(&self.data, pos) {
+                        Some(entry) if entry.encoding != 0 => entry,
+                        _ => {
+                            self.region = Region::Finished;
+                            continue;
+                        }
+                    };
+
+                    self.region = if entry.jump_distance == 0 {
+                        Region::Finished
+                    } else {
+                        Region::Unicode(pos + usize::from(entry.jump_distance))
+                    };
+
+                    if let Some(ch) = char::from_u32(u32::from(entry.encoding)) {
+                        return Some(ch);
+                    }
+                }
+                Region::Finished => return None,
+            }
+        }
+    }
+}

--- a/src/font_reader/mod.rs
+++ b/src/font_reader/mod.rs
@@ -99,23 +99,12 @@ impl FontReader {
 
         let mut glyph = GlyphSearcher::new(self);
 
-        if encoding <= 255 {
-            if encoding >= u16::from(b'a') {
-                glyph.jump_by(self.array_offset_lower_a.into());
-            } else if encoding >= u16::from(b'A') {
-                glyph.jump_by(self.array_offset_upper_a.into());
-            }
+        if let Ok(encoding) = u8::try_from(encoding) {
+            let offset = self
+                .find_glyph_offset(encoding)
+                .ok_or(LookupError::GlyphNotFound(ch))?;
 
-            loop {
-                // The terminator of the chain is not a glyph, so it is checked first.
-                if glyph.is_at_terminator() {
-                    return Err(LookupError::GlyphNotFound(ch));
-                }
-                if u16::from(glyph.get_ch()) == encoding {
-                    break;
-                }
-                glyph.jump_to_next();
-            }
+            glyph.jump_by(offset);
 
             Ok(glyph.into_glyph_reader())
         } else {
@@ -142,6 +131,17 @@ impl FontReader {
 
             Ok(glyph.into_glyph_reader())
         }
+    }
+
+    /// Resolves `encoding` to the offset of its glyph, relative to the start of
+    /// the glyph data.
+    fn find_glyph_offset(&self, encoding: u8) -> Option<usize> {
+        glyph_searcher::find_glyph_offset(
+            &self.data,
+            self.array_offset_upper_a,
+            self.array_offset_lower_a,
+            encoding,
+        )
     }
 }
 

--- a/src/font_reader/mod.rs
+++ b/src/font_reader/mod.rs
@@ -106,11 +106,15 @@ impl FontReader {
                 glyph.jump_by(self.array_offset_upper_a.into());
             }
 
-            while glyph.get_ch() as u16 != encoding {
-                glyph
-                    .jump_to_next()
-                    .then_some(())
-                    .ok_or(LookupError::GlyphNotFound(ch))?;
+            loop {
+                // The terminator of the chain is not a glyph, so it is checked first.
+                if glyph.is_at_terminator() {
+                    return Err(LookupError::GlyphNotFound(ch));
+                }
+                if u16::from(glyph.get_ch()) == encoding {
+                    break;
+                }
+                glyph.jump_to_next();
             }
 
             Ok(glyph.into_glyph_reader())
@@ -203,5 +207,15 @@ mod tests {
         let glyph = font.retrieve_glyph_data('☃');
 
         assert!(matches!(glyph, Err(LookupError::GlyphNotFound('☃'))));
+    }
+
+    #[test]
+    fn does_not_match_the_glyph_list_terminator() {
+        // The terminator of the single byte encoding glyph list has the encoding zero,
+        // but it is not a glyph.
+        let font = FontReader::new::<crate::fonts::u8g2_font_ncenB14_tr>();
+        let glyph = font.retrieve_glyph_data('\u{0}');
+
+        assert!(matches!(glyph, Err(LookupError::GlyphNotFound('\u{0}'))));
     }
 }

--- a/src/font_reader/mod.rs
+++ b/src/font_reader/mod.rs
@@ -1,7 +1,12 @@
 use crate::{utils::DebugIgnore, Font, LookupError};
 
-use self::{glyph_reader::GlyphReader, glyph_searcher::GlyphSearcher};
+use self::{
+    glyph_index::{GlyphIndex, IndexLookup},
+    glyph_reader::GlyphReader,
+    glyph_searcher::GlyphSearcher,
+};
 
+mod glyph_index;
 mod glyph_reader;
 mod glyph_renderer;
 mod glyph_searcher;
@@ -32,6 +37,7 @@ pub struct FontReader {
     pub array_offset_0x0100: u16,
     pub ignore_unknown_glyphs: bool,
     pub line_height: u32,
+    pub glyph_index: Option<&'static GlyphIndex>,
 }
 
 impl FontReader {
@@ -60,6 +66,7 @@ impl FontReader {
             array_offset_0x0100: u16::from_be_bytes([data[21], data[22]]),
             ignore_unknown_glyphs: false,
             line_height: 0,
+            glyph_index: None,
         };
         this.line_height = this.get_default_line_height() as u32;
         this
@@ -78,6 +85,12 @@ impl FontReader {
     pub const fn with_line_height(mut self, line_height: u32) -> Self {
         self.line_height = line_height;
         self
+    }
+
+    pub const fn new_indexed<F: Font>() -> Self {
+        let mut this = Self::new::<F>();
+        this.glyph_index = const { GlyphIndex::build_for::<F>() }.as_ref();
+        this
     }
 
     pub const fn get_default_line_height(&self) -> u8 {
@@ -135,7 +148,18 @@ impl FontReader {
 
     /// Resolves `encoding` to the offset of its glyph, relative to the start of
     /// the glyph data.
+    ///
+    /// Consults the glyph index if it is present and covers `encoding`, and walks
+    /// the jump chain otherwise.
     fn find_glyph_offset(&self, encoding: u8) -> Option<usize> {
+        if let Some(index) = self.glyph_index {
+            match index.lookup(encoding) {
+                IndexLookup::Found(offset) => return Some(offset),
+                IndexLookup::Absent => return None,
+                IndexLookup::NotCovered => (),
+            }
+        }
+
         glyph_searcher::find_glyph_offset(
             &self.data,
             self.array_offset_upper_a,
@@ -190,6 +214,7 @@ mod tests {
             array_offset_0x0100: 2,
             ignore_unknown_glyphs: false,
             line_height: 3,
+            glyph_index: None,
         };
 
         assert_eq!(format!("{font:?}"), format!("{expected:?}"));

--- a/src/font_reader/mod.rs
+++ b/src/font_reader/mod.rs
@@ -10,7 +10,10 @@ mod glyph_index;
 mod glyph_reader;
 mod glyph_renderer;
 mod glyph_searcher;
+mod glyphs;
 mod unicode_jumptable_reader;
+
+pub use glyphs::Glyphs;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FontReader {
@@ -96,6 +99,10 @@ impl FontReader {
     pub const fn get_default_line_height(&self) -> u8 {
         assert!(self.font_bounding_box_height >= 0);
         self.font_bounding_box_height as u8 + 1
+    }
+
+    pub fn glyphs(&self) -> Glyphs {
+        Glyphs::new(self)
     }
 
     pub fn try_retrieve_glyph_data(&self, ch: char) -> Result<Option<GlyphReader>, LookupError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,19 @@
 //! Those functions behave almost identical to their `render` counterparts, but don't actually perform any rendering. This
 //! can be very useful if the dimensions of the text are required for other drawing operations prior to the actual text rendering.
 //!
+//! ## Glyph Enumeration
+//!
+//! [`FontRenderer::glyphs()`] iterates over all characters that a font contains, which makes
+//! it possible to assert that a font provides exactly the characters an application needs:
+//!
+//! ```rust
+//! # use u8g2_fonts::FontRenderer;
+//! # use u8g2_fonts::fonts;
+//! let font = FontRenderer::new::<fonts::u8g2_font_courB10_tn>();
+//!
+//! assert!(font.glyphs().eq(" *+,-./0123456789:".chars()));
+//! ```
+//!
 //! ## Colors and Backgrounds
 //!
 //! While a foreground color must always be specified for rendering a font, there is also the option to set a background color.
@@ -150,6 +163,7 @@ pub use content::Content;
 pub use error::Error;
 pub use error::LookupError;
 pub use font::Font;
+pub use font_reader::Glyphs;
 pub use renderer::FontRenderer;
 
 #[cfg(feature = "embedded_graphics_textstyle")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,19 @@
 //!
 //! Note that [`FontRenderer::new()`] is `const`, so it can be crated as a global variable at compile time for optimal performance.
 //!
+//! ## Glyph Index
+//!
+//! [`FontRenderer::new_indexed()`] adds a lookup table from the printable ASCII characters
+//! (`' '` to `'~'`) to the position of their glyph inside of the font data. It is computed
+//! at compile time and lets every operation on those characters skip the search through the
+//! font's glyph list:
+//!
+//! ```rust
+//! # use u8g2_fonts::FontRenderer;
+//! # use u8g2_fonts::fonts;
+//! const FONT: FontRenderer = FontRenderer::new_indexed::<fonts::u8g2_font_haxrcorp4089_t_cyrillic>();
+//! ```
+//!
 //! ## Fonts
 //!
 //! The fonts are directly imported from [U8g2](https://github.com/olikraus/u8g2/wiki).

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -36,6 +36,36 @@ impl FontRenderer {
         }
     }
 
+    /// Creates a new instance of a font renderer with a compile time glyph index.
+    ///
+    /// The glyph index is a lookup table from the printable ASCII characters
+    /// (`' '` to `'~'`) to the position of their glyph inside of the font data.
+    /// It turns every glyph lookup of those characters into a table access,
+    /// instead of a search through the font's glyph list.
+    ///
+    /// Characters outside of the printable ASCII range are unaffected and are
+    /// searched for like [`FontRenderer::new()`] does. The same is true if any of
+    /// the glyph positions exceeds the [`u16`] range, in which case no index is
+    /// built at all.
+    ///
+    /// # Generics
+    ///
+    /// * `FONT` - the font to render. See [fonts](crate::fonts) for a list of available fonts
+    ///   and refer to [U8g2](https://github.com/olikraus/u8g2/wiki/fntlistall) for a more detailed description of each font.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use u8g2_fonts::FontRenderer;
+    /// # use u8g2_fonts::fonts;
+    /// const FONT: FontRenderer = FontRenderer::new_indexed::<fonts::u8g2_font_haxrcorp4089_t_cyrillic>();
+    /// ```
+    pub const fn new_indexed<FONT: Font>() -> Self {
+        Self {
+            font: FontReader::new_indexed::<FONT>(),
+        }
+    }
+
     /// Creates a new instance of a font renderer from custom font data.
     ///
     /// # Arguments
@@ -401,6 +431,15 @@ mod tests {
             "{:?}",
             FontRenderer::new::<crate::fonts::u8g2_font_u8glib_4_tf>()
         );
+    }
+
+    #[test]
+    fn new_indexed_builds_a_glyph_index() {
+        let plain = FontRenderer::new::<crate::fonts::u8g2_font_u8glib_4_tf>();
+        let indexed = FontRenderer::new_indexed::<crate::fonts::u8g2_font_u8glib_4_tf>();
+
+        assert!(plain.font.glyph_index.is_none());
+        assert!(indexed.font.glyph_index.is_some());
     }
 
     #[test]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,7 +7,7 @@ use crate::{
     content::{
         vertical_offset::compute_vertical_offset_from_static_newlines, LineDimensionsIterator,
     },
-    font_reader::FontReader,
+    font_reader::{FontReader, Glyphs},
     types::{FontColor, HorizontalAlignment, RenderedDimensions, VerticalPosition},
     utils::{combine_bounding_boxes, HorizontalRenderedDimensions},
     Content, Error, Font, LookupError,
@@ -107,6 +107,26 @@ impl FontRenderer {
     pub const fn with_line_height(mut self, line_height: u32) -> Self {
         self.font = self.font.with_line_height(line_height);
         self
+    }
+
+    /// Returns an iterator over all characters that this font contains.
+    ///
+    /// The characters are yielded in the order in which the font stores them,
+    /// which is ascending by code point.
+    ///
+    /// # Example
+    ///
+    /// Asserting that a font contains exactly the characters an application needs:
+    ///
+    /// ```rust
+    /// # use u8g2_fonts::FontRenderer;
+    /// # use u8g2_fonts::fonts;
+    /// let font = FontRenderer::new::<fonts::u8g2_font_courB10_tn>();
+    ///
+    /// assert!(font.glyphs().eq(" *+,-./0123456789:".chars()));
+    /// ```
+    pub fn glyphs(&self) -> Glyphs {
+        self.font.glyphs()
     }
 
     /// Renders text to a display.

--- a/src/u8g2_text_style.rs
+++ b/src/u8g2_text_style.rs
@@ -250,6 +250,10 @@ mod tests {
     #[test]
     fn is_debug_and_clone() {
         examine(U8g2TextStyle::new(fonts::u8g2_font_10x20_mf, Rgb888::RED));
+        examine(U8g2TextStyle::new_indexed(
+            fonts::u8g2_font_10x20_mf,
+            Rgb888::RED,
+        ));
     }
 
     // Dummy test for coverage; coverage requires unreachable!() branches to be covered,

--- a/src/u8g2_text_style.rs
+++ b/src/u8g2_text_style.rs
@@ -49,6 +49,19 @@ impl<C> U8g2TextStyle<C> {
             font: FontRenderer::new::<F>().with_ignore_unknown_chars(true),
         }
     }
+
+    /// Creates a text style with transparent background and a compile time glyph index.
+    ///
+    /// See [`FontRenderer::new_indexed()`] for a description of the glyph index.
+    pub const fn new_indexed<F: Font>(font: F, text_color: C) -> Self {
+        // font is a ZST, so it's safe to forget it
+        core::mem::forget(font);
+        Self {
+            text_color: Some(text_color),
+            background_color: None,
+            font: FontRenderer::new_indexed::<F>().with_ignore_unknown_chars(true),
+        }
+    }
 }
 
 impl<C> TextRenderer for U8g2TextStyle<C>

--- a/tests/embedded_graphics_fontstyle.rs
+++ b/tests/embedded_graphics_fontstyle.rs
@@ -262,6 +262,30 @@ mod textstyle_tests {
     }
 
     #[test]
+    fn indexed_style_measures_like_the_plain_style() {
+        let text = "Hello, W0rld! ~{|}^_`";
+        let position = Point::new(3, 17);
+
+        let plain = U8g2TextStyle::new(fonts::u8g2_font_ncenB14_tr, Rgb888::CSS_BLUE);
+        let indexed = U8g2TextStyle::new_indexed(fonts::u8g2_font_ncenB14_tr, Rgb888::CSS_BLUE);
+
+        for baseline in [
+            Baseline::Top,
+            Baseline::Middle,
+            Baseline::Bottom,
+            Baseline::Alphabetic,
+        ] {
+            let expected = plain.measure_string(text, position, baseline);
+            let actual = indexed.measure_string(text, position, baseline);
+
+            assert_eq!(actual.bounding_box, expected.bounding_box);
+            assert_eq!(actual.next_position, expected.next_position);
+        }
+
+        assert_eq!(indexed.line_height(), plain.line_height());
+    }
+
+    #[test]
     fn passes_on_error() {
         FailingDrawTarget::assert_passes_on_error(|display| {
             let mut character_style =

--- a/tests/glyphs.rs
+++ b/tests/glyphs.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeSet;
+
+use embedded_graphics_core::prelude::Point;
+use u8g2_fonts::{fonts, types::VerticalPosition, FontRenderer};
+
+const PRINTABLE_ASCII: &str = concat!(
+    " !\"#$%&'()*+,-./0123456789:;<=>?",
+    "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_",
+    "`abcdefghijklmnopqrstuvwxyz{|}~",
+);
+
+/// Runs `check` on a selection of fonts with different glyph ranges, bit widths and
+/// encodings. `check` receives the font name and a renderer of that font.
+fn for_each_test_font(check: impl Fn(&str, &FontRenderer)) {
+    macro_rules! check_font {
+        ($font:ty) => {
+            check(stringify!($font), &FontRenderer::new::<$font>())
+        };
+    }
+
+    check_font!(fonts::u8g2_font_ncenB14_tr);
+    check_font!(fonts::u8g2_font_courB10_tn);
+    check_font!(fonts::u8g2_font_lubBI08_tf);
+    check_font!(fonts::u8g2_font_u8glib_4_tf);
+    check_font!(fonts::u8g2_font_4x6_mr);
+    check_font!(fonts::u8g2_font_10x20_me);
+    check_font!(fonts::u8g2_font_haxrcorp4089_t_cyrillic);
+    check_font!(fonts::u8g2_font_unifont_t_symbols);
+}
+
+#[test]
+fn yields_the_exact_glyph_set_of_a_font() {
+    let font = FontRenderer::new::<fonts::u8g2_font_courB10_tn>();
+
+    assert_eq!(
+        font.glyphs().collect::<String>(),
+        " *+,-./0123456789:".to_string()
+    );
+}
+
+#[test]
+fn yields_printable_ascii_of_ascii_only_fonts() {
+    macro_rules! check_font {
+        ($font:ty) => {
+            assert_eq!(
+                FontRenderer::new::<$font>().glyphs().collect::<String>(),
+                PRINTABLE_ASCII,
+                "{}",
+                stringify!($font)
+            )
+        };
+    }
+
+    check_font!(fonts::u8g2_font_ncenB14_tr);
+    check_font!(fonts::u8g2_font_4x6_mr);
+    check_font!(fonts::u8g2_font_helvB08_tr);
+    check_font!(fonts::u8g2_font_fub25_tr);
+}
+
+#[test]
+fn yields_unicode_glyphs() {
+    let font = FontRenderer::new::<fonts::u8g2_font_haxrcorp4089_t_cyrillic>();
+    let glyphs = font.glyphs().collect::<Vec<_>>();
+
+    // The printable ASCII characters come first, the unicode characters after them.
+    assert_eq!(
+        glyphs.iter().take(95).collect::<String>(),
+        PRINTABLE_ASCII.to_string()
+    );
+
+    let unicode = &glyphs[95..];
+    assert_eq!(unicode.len(), 63);
+    assert_eq!(unicode[0], '\u{410}');
+    assert_eq!(unicode[unicode.len() - 1], '\u{44f}');
+    assert!(unicode.iter().all(|ch| *ch > '\u{ff}'));
+}
+
+#[test]
+fn yields_ascending_and_unique_characters() {
+    for_each_test_font(|name, font| {
+        let glyphs = font.glyphs().collect::<Vec<_>>();
+
+        assert!(!glyphs.is_empty(), "{name} has no glyphs");
+        assert!(
+            glyphs.windows(2).all(|w| w[0] < w[1]),
+            "{name} is not sorted ascending"
+        );
+        assert_eq!(
+            glyphs.len(),
+            glyphs.iter().collect::<BTreeSet<_>>().len(),
+            "{name} yields duplicates"
+        );
+    });
+}
+
+#[test]
+fn every_yielded_character_is_retrievable() {
+    for_each_test_font(|name, font| {
+        for ch in font.glyphs() {
+            font.get_rendered_dimensions(ch, Point::new(0, 0), VerticalPosition::Baseline)
+                .unwrap_or_else(|e| panic!("{name}: {ch:?} is not retrievable: {e}"));
+        }
+    });
+}
+
+#[test]
+fn characters_that_are_not_yielded_are_not_retrievable() {
+    for_each_test_font(|name, font| {
+        let glyphs = font.glyphs().collect::<BTreeSet<_>>();
+
+        for ch in '\u{0}'..='\u{ff}' {
+            if ch == '\n' {
+                // Newlines are line breaks rather than glyphs.
+                continue;
+            }
+
+            let retrievable = font
+                .get_rendered_dimensions(ch, Point::new(0, 0), VerticalPosition::Baseline)
+                .is_ok();
+
+            assert_eq!(
+                retrievable,
+                glyphs.contains(&ch),
+                "{name}: {ch:?} retrievable: {retrievable}, yielded: {}",
+                glyphs.contains(&ch)
+            );
+        }
+    });
+}
+
+#[test]
+fn unicode_characters_that_are_not_yielded_are_not_retrievable() {
+    let font = FontRenderer::new::<fonts::u8g2_font_haxrcorp4089_t_cyrillic>();
+    let glyphs = font.glyphs().collect::<BTreeSet<_>>();
+
+    for ch in '\u{100}'..='\u{500}' {
+        let retrievable = font
+            .get_rendered_dimensions(ch, Point::new(0, 0), VerticalPosition::Baseline)
+            .is_ok();
+
+        assert_eq!(retrievable, glyphs.contains(&ch), "{ch:?}");
+    }
+}
+
+#[test]
+fn the_glyph_list_terminator_is_not_a_glyph() {
+    let font = FontRenderer::new::<fonts::u8g2_font_ncenB14_tr>();
+
+    assert!(!font.glyphs().any(|ch| ch == '\u{0}'));
+}

--- a/tests/glyphs.rs
+++ b/tests/glyphs.rs
@@ -143,6 +143,20 @@ fn unicode_characters_that_are_not_yielded_are_not_retrievable() {
 }
 
 #[test]
+fn is_debug_and_clone() {
+    let font = FontRenderer::new::<fonts::u8g2_font_courB10_tn>();
+    let mut glyphs = font.glyphs();
+
+    assert!(!format!("{glyphs:?}").is_empty());
+
+    glyphs.next().unwrap();
+    assert_eq!(
+        glyphs.clone().collect::<String>(),
+        glyphs.collect::<String>()
+    );
+}
+
+#[test]
 fn the_glyph_list_terminator_is_not_a_glyph() {
     let font = FontRenderer::new::<fonts::u8g2_font_ncenB14_tr>();
 


### PR DESCRIPTION
Hi, this PR fixes a small bug (when searching for `\0` it gave the index of terminator), adds an iterator of glyphs that are stored in a font (now we can write tests to ensure that fonts only contain glyphs we need) and an optional (though imo it can be always present) const glyph index for ASCII chars (so instead of iterating the font for each ASCII char, it will do a fast lookup into a small table, giving *a big* speed boost).